### PR TITLE
Auto-deploy to NAS on push to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,44 @@
+name: Deploy to NAS
+
+# NOTE: NAS SSH access is manually enabled for 6-hour windows.
+# If deploy fails with "websocket: bad handshake", the SSH window
+# is closed. Re-enable SSH on the NAS and re-run the workflow.
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: []
+    env:
+      TUNNEL_SERVICE_TOKEN_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+      TUNNEL_SERVICE_TOKEN_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+
+    steps:
+      - name: Install cloudflared
+        run: |
+          curl -fsSL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb -o cloudflared.deb
+          sudo dpkg -i cloudflared.deb
+
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+
+          cat > ~/.ssh/config <<EOF
+          Host nas-ssh
+            HostName nas-ssh.murphy52.xyz
+            User Murphy52
+            IdentityFile ~/.ssh/deploy_key
+            ProxyCommand cloudflared access ssh --hostname %h
+            StrictHostKeyChecking no
+          EOF
+          chmod 600 ~/.ssh/config
+
+      - name: Deploy
+        run: |
+          ssh -o ConnectTimeout=30 nas-ssh 'set -e; cd /home/Murphy52/docker/apps/phishpicker; echo "=== Pulling latest ==="; git pull origin main; echo "=== Building and restarting ==="; docker compose up -d --build; echo "=== Done ==="'


### PR DESCRIPTION
## Summary
Adds `.github/workflows/deploy.yml`, mirroring Daytrader's: on push to `main`, installs `cloudflared`, SSHes to the NAS over Cloudflare Access, then `git pull` + `docker compose up -d --build` at `/home/Murphy52/docker/apps/phishpicker`.

Scope intentionally limited to code redeploys. Model files (`api/data/model.lgb`, `api/data/model.meta.json`) live on the NAS under the bind-mounted data dir; shipping a new model is still done with `scripts/deploy_to_nas.sh`.

## Before merging — set these repo secrets
Daytrader already has identical values:

- `CF_ACCESS_CLIENT_ID`
- `CF_ACCESS_CLIENT_SECRET`
- `DEPLOY_SSH_KEY`

Without them the first run will fail fast at the cloudflared/SSH step.

## Known caveat
NAS SSH is gated to a manual 6-hour window. If deploy fails with `websocket: bad handshake`, re-enable SSH on the NAS and re-run the job (noted in the workflow file).

## Test plan
- [ ] Copy the three secrets from Daytrader into this repo
- [ ] Merge and confirm the resulting `Deploy to NAS` run succeeds
- [ ] Check NAS: `docker compose ps` shows api + web running, web reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)